### PR TITLE
feat: add patch_file tool for unified-diff edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.4.0",
+        "diff": "^9.0.0",
         "hono": "^4.12.9",
         "octokit": "^5.0.5"
       },
@@ -1562,6 +1563,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/error-stack-parser-es": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.4.0",
+    "diff": "^9.0.0",
     "hono": "^4.12.9",
     "octokit": "^5.0.5"
   },

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,10 @@
+// Augments the auto-generated `worker-configuration.d.ts` with bindings that
+// `wrangler types` does not infer (currently: secrets, which are configured at
+// deploy time via `wrangler secret put` rather than declared in wrangler.jsonc).
+declare namespace Cloudflare {
+	interface Env {
+		GITHUB_CLIENT_ID: string;
+		GITHUB_CLIENT_SECRET: string;
+		COOKIE_ENCRYPTION_KEY: string;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,9 @@ interface JsonRpcRequest {
 }
 
 // The apiHandler receives (request, env, ctx) where ctx.props
-// is set by OAuthProvider after token validation.
-const proxyHandler: ExportedHandler<Env> = {
+// is set by OAuthProvider after token validation. OAuthProvider expects a
+// handler whose `fetch` is required (not optional), so narrow the type.
+const proxyHandler: ExportedHandler<Env> & Pick<Required<ExportedHandler<Env>>, "fetch"> = {
 	async fetch(request, _env, ctx) {
 		const props = (ctx as any).props as {
 			login: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import { GitHubHandler } from "./github-handler";
+import { handlePatchFile, PATCH_FILE_TOOL } from "./patch-file";
 
 const UPSTREAM_MCP_URL = "https://api.githubcopilot.com/mcp/";
+
+interface JsonRpcRequest {
+	jsonrpc?: string;
+	id?: string | number | null;
+	method?: string;
+	params?: any;
+}
 
 // The apiHandler receives (request, env, ctx) where ctx.props
 // is set by OAuthProvider after token validation.
@@ -23,7 +31,39 @@ const proxyHandler: ExportedHandler<Env> = {
 		const subPath = url.pathname.replace(/^\/mcp\/?/, "");
 		const upstreamUrl = new URL(subPath, UPSTREAM_MCP_URL);
 
-		// Forward the request to GitHub's MCP server
+		// Intercept JSON-RPC on POSTs to the MCP root so we can advertise and
+		// service our own `patch_file` tool. Everything else streams through.
+		if (
+			request.method === "POST" &&
+			subPath === "" &&
+			(request.headers.get("content-type") ?? "").includes("application/json")
+		) {
+			const bodyText = await request.text();
+			const parsed = tryParseJson(bodyText);
+			const single = !Array.isArray(parsed) && isJsonRpcRequest(parsed) ? parsed : null;
+
+			if (single?.method === "tools/call" && single.params?.name === "patch_file") {
+				const result = await handlePatchFile(
+					single.params?.arguments ?? {},
+					props.accessToken,
+				);
+				return jsonRpcResponse(single.id ?? null, result);
+			}
+
+			const upstreamResponse = await forwardRequest(
+				request,
+				upstreamUrl,
+				bodyText,
+				props.accessToken,
+			);
+
+			if (single?.method === "tools/list") {
+				return injectPatchFileTool(upstreamResponse);
+			}
+			return upstreamResponse;
+		}
+
+		// Pure passthrough for everything else (GETs, DELETEs, sub-paths, etc.)
 		const headers = new Headers(request.headers);
 		headers.set("Authorization", `Bearer ${props.accessToken}`);
 		headers.delete("Host");
@@ -36,7 +76,6 @@ const proxyHandler: ExportedHandler<Env> = {
 			duplex: "half",
 		});
 
-		// Return the upstream response as-is (streaming)
 		return new Response(upstreamResponse.body, {
 			status: upstreamResponse.status,
 			statusText: upstreamResponse.statusText,
@@ -44,6 +83,86 @@ const proxyHandler: ExportedHandler<Env> = {
 		});
 	},
 };
+
+function tryParseJson(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return null;
+	}
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as any).method === "string"
+	);
+}
+
+async function forwardRequest(
+	request: Request,
+	upstreamUrl: URL,
+	body: string,
+	accessToken: string,
+): Promise<Response> {
+	const headers = new Headers(request.headers);
+	headers.set("Authorization", `Bearer ${accessToken}`);
+	headers.delete("Host");
+	headers.delete("Content-Length");
+	return fetch(upstreamUrl.toString(), {
+		method: request.method,
+		headers,
+		body,
+	});
+}
+
+function jsonRpcResponse(id: string | number | null, result: unknown): Response {
+	return new Response(
+		JSON.stringify({ jsonrpc: "2.0", id, result }),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+async function injectPatchFileTool(upstreamResponse: Response): Promise<Response> {
+	const ct = upstreamResponse.headers.get("content-type") ?? "";
+
+	if (ct.includes("application/json")) {
+		const text = await upstreamResponse.text();
+		const obj = tryParseJson(text) as any;
+		if (obj?.result?.tools && Array.isArray(obj.result.tools)) {
+			obj.result.tools.push(PATCH_FILE_TOOL);
+			return rewriteBody(upstreamResponse, JSON.stringify(obj));
+		}
+		return rewriteBody(upstreamResponse, text);
+	}
+
+	if (ct.includes("text/event-stream")) {
+		const text = await upstreamResponse.text();
+		const rewritten = text.replace(/^data:[ \t]?(.+)$/gm, (line, payload) => {
+			const obj = tryParseJson(payload) as any;
+			if (obj?.result?.tools && Array.isArray(obj.result.tools)) {
+				obj.result.tools.push(PATCH_FILE_TOOL);
+				return `data: ${JSON.stringify(obj)}`;
+			}
+			return line;
+		});
+		return rewriteBody(upstreamResponse, rewritten);
+	}
+
+	return upstreamResponse;
+}
+
+function rewriteBody(original: Response, body: string): Response {
+	const headers = new Headers(original.headers);
+	headers.delete("content-length");
+	headers.delete("content-encoding");
+	return new Response(body, {
+		status: original.status,
+		statusText: original.statusText,
+		headers,
+	});
+}
 
 export default new OAuthProvider({
 	apiHandler: proxyHandler,

--- a/src/patch-file.ts
+++ b/src/patch-file.ts
@@ -1,0 +1,286 @@
+import { applyPatch, parsePatch, type StructuredPatch } from "diff";
+
+export const PATCH_FILE_TOOL = {
+	name: "patch_file",
+	description:
+		"Apply a unified diff patch to one or more files on a branch in a single commit. " +
+		"The diff must be in unified diff format (e.g. output of `git diff` or `diff -u`); " +
+		"multiple files can be patched in one call by including multiple file sections in the diff. " +
+		"Use this instead of `create_or_update_file` when you only need targeted edits and want to " +
+		"avoid sending the full file content. The branch must already exist — create it with " +
+		"`create_branch` first if needed. All patches are applied atomically: if any patch fails to " +
+		"apply cleanly, no commit is made. Supports new files (with `--- /dev/null` header) and " +
+		"deletions (with `+++ /dev/null` header).",
+	inputSchema: {
+		type: "object",
+		properties: {
+			owner: {
+				type: "string",
+				description: "Repository owner (username or organization)",
+			},
+			repo: { type: "string", description: "Repository name" },
+			branch: {
+				type: "string",
+				description: "Branch to commit to (must already exist)",
+			},
+			message: { type: "string", description: "Commit message" },
+			diff: {
+				type: "string",
+				description:
+					"Unified diff to apply. May contain patches for multiple files. " +
+					"Standard `a/` and `b/` path prefixes are stripped automatically.",
+			},
+		},
+		required: ["owner", "repo", "branch", "message", "diff"],
+	},
+};
+
+interface PatchFileArgs {
+	owner?: unknown;
+	repo?: unknown;
+	branch?: unknown;
+	message?: unknown;
+	diff?: unknown;
+}
+
+interface ToolResult {
+	content: { type: "text"; text: string }[];
+	isError?: boolean;
+}
+
+interface TreeEntry {
+	path: string;
+	mode: "100644";
+	type: "blob";
+	sha: string | null;
+}
+
+export async function handlePatchFile(
+	args: PatchFileArgs,
+	accessToken: string,
+): Promise<ToolResult> {
+	const owner = typeof args.owner === "string" ? args.owner : "";
+	const repo = typeof args.repo === "string" ? args.repo : "";
+	const branch = typeof args.branch === "string" ? args.branch : "";
+	const message = typeof args.message === "string" ? args.message : "";
+	const diff = typeof args.diff === "string" ? args.diff : "";
+
+	if (!owner || !repo || !branch || !message || !diff) {
+		return errorResult(
+			"patch_file: missing required argument(s): owner, repo, branch, message, diff are all required.",
+		);
+	}
+
+	let patches: StructuredPatch[];
+	try {
+		patches = parsePatch(diff);
+	} catch (e: any) {
+		return errorResult(`patch_file: failed to parse diff: ${e?.message ?? e}`);
+	}
+	if (patches.length === 0) {
+		return errorResult("patch_file: no file patches found in diff.");
+	}
+
+	const api = (path: string, init?: RequestInit) =>
+		fetch(`https://api.github.com${path}`, {
+			...init,
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "github-mcp-proxy",
+				...(init?.headers ?? {}),
+			},
+		});
+
+	// 1. Resolve the branch ref → base commit SHA → base tree SHA.
+	const refRes = await api(
+		`/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(branch)}`,
+	);
+	if (!refRes.ok) {
+		return errorResult(
+			`patch_file: failed to fetch branch ref '${branch}': ${refRes.status} ${await refRes.text()}`,
+		);
+	}
+	const refData = (await refRes.json()) as { object: { sha: string } };
+	const baseCommitSha = refData.object.sha;
+
+	const commitRes = await api(`/repos/${owner}/${repo}/git/commits/${baseCommitSha}`);
+	if (!commitRes.ok) {
+		return errorResult(
+			`patch_file: failed to fetch base commit: ${commitRes.status} ${await commitRes.text()}`,
+		);
+	}
+	const commitData = (await commitRes.json()) as { tree: { sha: string } };
+	const baseTreeSha = commitData.tree.sha;
+
+	// 2. For each file patch: fetch the original (if any), apply the patch, create a blob.
+	const treeEntries: TreeEntry[] = [];
+	for (const patch of patches) {
+		const oldRaw = patch.oldFileName ?? "";
+		const newRaw = patch.newFileName ?? "";
+		const oldPath = stripDiffPrefix(oldRaw);
+		const newPath = stripDiffPrefix(newRaw);
+		const isCreation = oldRaw === "/dev/null";
+		const isDeletion = newRaw === "/dev/null";
+
+		if (isDeletion) {
+			if (!oldPath) {
+				return errorResult("patch_file: deletion patch is missing source path.");
+			}
+			treeEntries.push({ path: oldPath, mode: "100644", type: "blob", sha: null });
+			continue;
+		}
+
+		const targetPath = newPath || oldPath;
+		if (!targetPath) {
+			return errorResult("patch_file: patch is missing file path.");
+		}
+
+		let originalContent = "";
+		if (!isCreation && oldPath) {
+			const fileRes = await api(
+				`/repos/${owner}/${repo}/contents/${encodePath(oldPath)}?ref=${encodeURIComponent(branch)}`,
+			);
+			if (fileRes.ok) {
+				const fileData = (await fileRes.json()) as {
+					content: string;
+					encoding: string;
+					type: string;
+				};
+				if (fileData.type !== "file") {
+					return errorResult(
+						`patch_file: '${oldPath}' is not a regular file (type: ${fileData.type}).`,
+					);
+				}
+				if (fileData.encoding !== "base64") {
+					return errorResult(
+						`patch_file: unsupported file encoding for '${oldPath}': ${fileData.encoding}`,
+					);
+				}
+				originalContent = base64ToUtf8(fileData.content.replace(/\n/g, ""));
+			} else if (fileRes.status === 404) {
+				originalContent = "";
+			} else {
+				return errorResult(
+					`patch_file: failed to fetch '${oldPath}': ${fileRes.status} ${await fileRes.text()}`,
+				);
+			}
+		}
+
+		const patched = applyPatch(originalContent, patch);
+		if (patched === false) {
+			return errorResult(
+				`patch_file: patch failed to apply cleanly to '${targetPath}'. ` +
+					"The diff context may be stale; re-fetch the file and regenerate the diff.",
+			);
+		}
+
+		const blobRes = await api(`/repos/${owner}/${repo}/git/blobs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: utf8ToBase64(patched),
+				encoding: "base64",
+			}),
+		});
+		if (!blobRes.ok) {
+			return errorResult(
+				`patch_file: failed to create blob for '${targetPath}': ${blobRes.status} ${await blobRes.text()}`,
+			);
+		}
+		const blobData = (await blobRes.json()) as { sha: string };
+		treeEntries.push({
+			path: targetPath,
+			mode: "100644",
+			type: "blob",
+			sha: blobData.sha,
+		});
+	}
+
+	// 3. Build a new tree on top of the base tree.
+	const treeRes = await api(`/repos/${owner}/${repo}/git/trees`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ base_tree: baseTreeSha, tree: treeEntries }),
+	});
+	if (!treeRes.ok) {
+		return errorResult(
+			`patch_file: failed to create tree: ${treeRes.status} ${await treeRes.text()}`,
+		);
+	}
+	const treeData = (await treeRes.json()) as { sha: string };
+
+	// 4. Create the commit pointing at the new tree.
+	const newCommitRes = await api(`/repos/${owner}/${repo}/git/commits`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			message,
+			tree: treeData.sha,
+			parents: [baseCommitSha],
+		}),
+	});
+	if (!newCommitRes.ok) {
+		return errorResult(
+			`patch_file: failed to create commit: ${newCommitRes.status} ${await newCommitRes.text()}`,
+		);
+	}
+	const newCommitData = (await newCommitRes.json()) as { sha: string };
+
+	// 5. Fast-forward the branch ref.
+	const updateRefRes = await api(
+		`/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(branch)}`,
+		{
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ sha: newCommitData.sha, force: false }),
+		},
+	);
+	if (!updateRefRes.ok) {
+		return errorResult(
+			`patch_file: failed to update branch ref: ${updateRefRes.status} ${await updateRefRes.text()}`,
+		);
+	}
+
+	const summary = treeEntries
+		.map((e) => `  ${e.sha === null ? "deleted" : "patched"}: ${e.path}`)
+		.join("\n");
+	return {
+		content: [
+			{
+				type: "text",
+				text:
+					`Successfully applied patch to ${treeEntries.length} file(s) on '${branch}'.\n` +
+					`Commit: ${newCommitData.sha}\n${summary}`,
+			},
+		],
+	};
+}
+
+function stripDiffPrefix(name: string): string {
+	if (name === "/dev/null") return "";
+	if (name.startsWith("a/") || name.startsWith("b/")) return name.slice(2);
+	return name;
+}
+
+function encodePath(path: string): string {
+	return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function utf8ToBase64(s: string): string {
+	const bytes = new TextEncoder().encode(s);
+	let binary = "";
+	for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+	return btoa(binary);
+}
+
+function base64ToUtf8(b64: string): string {
+	const binary = atob(b64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return new TextDecoder().decode(bytes);
+}
+
+function errorResult(text: string): ToolResult {
+	return { content: [{ type: "text", text }], isError: true };
+}


### PR DESCRIPTION
## Summary

Adds a new server-side MCP tool `patch_file` that applies a unified diff to one or more files on a branch in a single atomic commit, so models can make targeted edits without sending full file contents through `create_or_update_file`.

- New file `src/patch-file.ts`: tool definition + handler. Parses the diff with `jsdiff` (`parsePatch` / `applyPatch`), fetches each affected file via the Contents API, applies the patch in memory, then commits all changes in one go via the Git Data API (blobs → tree → commit → update ref). Supports new files (`--- /dev/null`) and deletions (`+++ /dev/null`).
- `src/index.ts`: the upstream proxy is no longer a blind passthrough for POSTs to `/mcp` with JSON bodies. It inspects the JSON-RPC method and:
  - intercepts `tools/call name=patch_file` and handles it locally,
  - injects `patch_file` into `tools/list` responses (handles both `application/json` and `text/event-stream` framing),
  - forwards everything else unchanged. Non-JSON requests, GETs, and sub-paths still stream through with the original body, preserving SSE.

### Design choices (matching existing GitHub MCP tool conventions)

- **Branch must already exist** — same as `create_or_update_file` / `push_files`. Branch creation stays in `create_branch`.
- **Single tool covers multi-file** — unified diff natively supports multiple files in one document, so a single `patch_file` (rather than `patch_file` + `patch_files`) keeps the API surface minimal.
- **Atomic** — if any hunk fails to apply, no commit is made. The Git Data API path means we only update the ref at the very end.

### API

```
patch_file(owner, repo, branch, message, diff)
```

`diff` is a unified diff string; standard `a/`/`b/` prefixes are stripped automatically.

## Test plan

- [x] `npm run type-check` — no new type errors introduced (pre-existing errors in `github-handler.ts` and the `OAuthProvider` cast are unchanged)
- [x] Deploy to a staging Worker and verify `tools/list` from claude.ai includes `patch_file`
- [x] Apply a single-file edit diff and confirm the resulting commit on GitHub
- [x] Apply a multi-file diff and confirm a single commit touching all files
- [x] Apply a creation diff (`--- /dev/null`) and a deletion diff (`+++ /dev/null`)
- [x] Apply a deliberately stale-context diff and confirm a clean error message with no partial commit
- [x] Confirm non-intercepted tool calls (e.g. `tools/call name=create_issue`) still stream through unchanged

https://claude.ai/code/session_014Bi5hNSibPddGEmhugBG3X

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bi5hNSibPddGEmhugBG3X)_