### PR TITLE
feat: enable all upstream toolsets (incl. actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use this as a custom MCP connector on claude.ai to get full access to GitHub's M
 
 1. Client connects to your Worker's `/mcp` endpoint
 2. Worker triggers GitHub OAuth flow (with `read:user,repo` scopes)
-3. After authentication, the Worker transparently proxies all MCP requests to `api.githubcopilot.com/mcp/`, injecting the user's GitHub token as `Authorization: Bearer`
+3. After authentication, the Worker transparently proxies all MCP requests to `api.githubcopilot.com/mcp/x/all/` (all toolsets enabled, including `actions`), injecting the user's GitHub token as `Authorization: Bearer`
 
 ## Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import { GitHubHandler } from "./github-handler";
 import { handlePatchFiles, PATCH_FILES_TOOL } from "./patch-files";
 
-const UPSTREAM_MCP_URL = "https://api.githubcopilot.com/mcp/";
+const UPSTREAM_MCP_URL = "https://api.githubcopilot.com/mcp/x/all/";
 
 interface JsonRpcRequest {
 	jsonrpc?: string;


### PR DESCRIPTION
## Summary
- `UPSTREAM_MCP_URL` を `https://api.githubcopilot.com/mcp/` から `https://api.githubcopilot.com/mcp/x/all/` に変更し、リモート GitHub MCP サーバーの全 toolset を有効化
- これまでデフォルト toolset (`context, repos, issues, pull_requests, users`) のみ露出していたため、**Actions 関連ツールが利用不可**だった
- 今回の変更で `actions_list` / `actions_get` / `actions_run_trigger` / `get_job_logs` などの workflow 操作ツールが利用可能になる
- 同時に `code_security`, `dependabot`, `discussions`, `gists`, `notifications`, `orgs`, `projects`, `secret_protection`, `security_advisories`, `labels` 等の他 toolset も解放

## Notes
- OAuth scope は据え置き (`read:user,repo`)。`actions_run_trigger` 等の実行は `repo` scope で動作する
- workflow YAML の編集 (`patch_files` で `.github/workflows/*.yml` を変更) には別途 `workflow` scope が必要だが、これは本 PR のスコープ外

## Test plan
- [ ] Cloudflare Worker にデプロイし、claude.ai の MCP コネクタから接続
- [ ] `tools/list` で `actions_*` 系ツールが含まれることを確認
- [ ] `actions_list` でリポジトリの workflow 一覧が取得できること
- [ ] `actions_run_trigger` で workflow_dispatch を実行できること
- [ ] `get_job_logs` で job ログが取得できること
- [ ] 既存の `patch_files` ツール挿入が引き続き動作すること

https://claude.ai/code/session_0124PUwSEC3fV5NhPp6hET4q

---
_Generated by [Claude Code](https://claude.ai/code/session_0124PUwSEC3fV5NhPp6hET4q)_