### PR TITLE
feat: add download_repository_archive tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ npm run deploy
 3. Claude will redirect you to GitHub for authentication
 4. Once authorized, all GitHub MCP tools become available in your conversations
 
+## Custom tools
+
+On top of the upstream GitHub MCP toolset, the proxy advertises and services a
+few tools of its own:
+
+- **`patch_files`** — apply targeted text edits to existing files on a branch in
+  a single atomic commit.
+- **`download_repository_archive`** — get a temporary, signed download URL for a
+  repository archive. The request is authenticated with the user's token, so it
+  works for **private** repositories. The proxy follows the GitHub archive
+  endpoint's redirect and returns the resulting `codeload.github.com` URL, which
+  is short-lived and downloadable without further authentication (the GitHub
+  token is never embedded in the URL). Arguments: `owner`, `repo`, optional
+  `ref` (branch/tag/SHA, defaults to the repository's default branch), and
+  optional `format` (`zip` or `tar.gz`, defaults to `zip`).
+
 ## Local development
 
 ```bash

--- a/src/download-archive.test.ts
+++ b/src/download-archive.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DOWNLOAD_ARCHIVE_TOOL, handleDownloadArchive } from "./download-archive";
+
+const TOKEN = "ghs_test_token";
+
+function redirectResponse(location: string, status = 302): Response {
+	return new Response(null, {
+		status,
+		headers: location ? { Location: location } : {},
+	});
+}
+
+function expectErrorResult(
+	result: Awaited<ReturnType<typeof handleDownloadArchive>>,
+	matcher: RegExp,
+) {
+	expect(result.isError).toBe(true);
+	expect(result.content[0]?.text).toMatch(matcher);
+}
+
+describe("DOWNLOAD_ARCHIVE_TOOL schema", () => {
+	it("declares the expected name and required fields", () => {
+		expect(DOWNLOAD_ARCHIVE_TOOL.name).toBe("download_repository_archive");
+		expect(DOWNLOAD_ARCHIVE_TOOL.inputSchema.required).toEqual(["owner", "repo"]);
+		expect(DOWNLOAD_ARCHIVE_TOOL.inputSchema.properties.format.enum).toEqual([
+			"zip",
+			"tar.gz",
+		]);
+	});
+});
+
+describe("handleDownloadArchive - argument validation", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("rejects missing required arguments", async () => {
+		const result = await handleDownloadArchive({ owner: "o" }, TOKEN);
+		expectErrorResult(result, /missing required argument/i);
+	});
+
+	it("does not call the GitHub API for invalid input", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch");
+		await handleDownloadArchive({}, TOKEN);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unknown format", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch");
+		const result = await handleDownloadArchive(
+			{ owner: "o", repo: "r", format: "rar" },
+			TOKEN,
+		);
+		expectErrorResult(result, /invalid format 'rar'/);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleDownloadArchive - GitHub API flow", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("returns the signed redirect URL for a default-branch zip", async () => {
+		const signed = "https://codeload.github.com/o/r/legacy.zip/refs/heads/main?token=abc";
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(redirectResponse(signed));
+
+		const result = await handleDownloadArchive({ owner: "o", repo: "r" }, TOKEN);
+
+		expect(result.isError).toBeUndefined();
+		expect(result.content[0]?.text).toContain(signed);
+		expect(result.content[0]?.text).toContain("(default branch)");
+		expect(result.content[0]?.text).toContain("(zip)");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [calledUrl, init] = fetchMock.mock.calls[0];
+		expect(calledUrl).toBe("https://api.github.com/repos/o/r/zipball");
+		expect((init as RequestInit).redirect).toBe("manual");
+		const headers = (init as RequestInit).headers as Record<string, string>;
+		expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(headers["User-Agent"]).toBe("github-mcp-proxy");
+	});
+
+	it("uses the tarball endpoint for tar.gz and includes the ref in the path", async () => {
+		const signed = "https://codeload.github.com/o/r/tar.gz/v1.0?token=xyz";
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(redirectResponse(signed));
+
+		const result = await handleDownloadArchive(
+			{ owner: "o", repo: "r", ref: "v1.0", format: "tar.gz" },
+			TOKEN,
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(result.content[0]?.text).toContain(signed);
+		expect(result.content[0]?.text).toContain("v1.0");
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			"https://api.github.com/repos/o/r/tarball/v1.0",
+		);
+	});
+
+	it("URL-encodes ref segments while preserving slashes", async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(redirectResponse("https://codeload.github.com/x"));
+
+		await handleDownloadArchive(
+			{ owner: "o", repo: "r", ref: "feature/new thing" },
+			TOKEN,
+		);
+
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			"https://api.github.com/repos/o/r/zipball/feature/new%20thing",
+		);
+	});
+
+	it("errors when the redirect has no Location header", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(redirectResponse(""));
+
+		const result = await handleDownloadArchive({ owner: "o", repo: "r" }, TOKEN);
+		expectErrorResult(result, /without a Location header/);
+	});
+
+	it("maps a 404 to a not-found error", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response("nope", { status: 404 }),
+		);
+
+		const result = await handleDownloadArchive(
+			{ owner: "o", repo: "missing", ref: "main" },
+			TOKEN,
+		);
+		expectErrorResult(result, /not found, or the token lacks access/);
+	});
+
+	it("surfaces unexpected status codes", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response("boom", { status: 500 }),
+		);
+
+		const result = await handleDownloadArchive({ owner: "o", repo: "r" }, TOKEN);
+		expectErrorResult(result, /unexpected response from GitHub: 500/);
+	});
+
+	it("handles fetch rejections gracefully", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network down"));
+
+		const result = await handleDownloadArchive({ owner: "o", repo: "r" }, TOKEN);
+		expectErrorResult(result, /request to GitHub failed.*network down/);
+	});
+});

--- a/src/download-archive.ts
+++ b/src/download-archive.ts
@@ -1,0 +1,148 @@
+export const DOWNLOAD_ARCHIVE_TOOL = {
+	name: "download_repository_archive",
+	description:
+		"Get a temporary, signed download URL for a repository archive (zip or tar.gz) via the GitHub " +
+		"archive API. Works for private repositories because the request is authenticated with the user's " +
+		"token. The tool follows the archive endpoint's redirect and returns the resulting " +
+		"`codeload.github.com` URL, which is short-lived (valid for roughly a few minutes) and can be " +
+		"downloaded without any additional authentication — the GitHub token is NOT embedded in the URL. " +
+		"Use `ref` to pick a branch, tag, or commit SHA; when omitted, the repository's default branch is " +
+		"used. This does not clone into the local filesystem; it returns a URL you (or a downstream tool) " +
+		"can fetch the archive from.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			owner: {
+				type: "string",
+				description: "Repository owner (username or organization)",
+			},
+			repo: { type: "string", description: "Repository name" },
+			ref: {
+				type: "string",
+				description:
+					"Branch, tag, or commit SHA to archive. Omit to use the repository's default branch.",
+			},
+			format: {
+				type: "string",
+				enum: ["zip", "tar.gz"],
+				description:
+					"Archive format: 'zip' (default, uses the zipball endpoint) or 'tar.gz' (uses the tarball endpoint).",
+			},
+		},
+		required: ["owner", "repo"],
+	},
+};
+
+interface DownloadArchiveArgs {
+	owner?: unknown;
+	repo?: unknown;
+	ref?: unknown;
+	format?: unknown;
+}
+
+interface ToolResult {
+	content: { type: "text"; text: string }[];
+	isError?: boolean;
+}
+
+export async function handleDownloadArchive(
+	args: DownloadArchiveArgs,
+	accessToken: string,
+): Promise<ToolResult> {
+	const owner = typeof args.owner === "string" ? args.owner : "";
+	const repo = typeof args.repo === "string" ? args.repo : "";
+	const ref = typeof args.ref === "string" ? args.ref : "";
+
+	if (!owner || !repo) {
+		return errorResult(
+			"download_repository_archive: missing required argument(s): owner and repo are required.",
+		);
+	}
+
+	let format: "zip" | "tar.gz";
+	if (args.format === undefined || args.format === "zip") {
+		format = "zip";
+	} else if (args.format === "tar.gz") {
+		format = "tar.gz";
+	} else {
+		return errorResult(
+			`download_repository_archive: invalid format '${String(args.format)}'. Use 'zip' or 'tar.gz'.`,
+		);
+	}
+
+	const endpoint = format === "zip" ? "zipball" : "tarball";
+	// The archive endpoints accept an optional ref as a trailing path segment.
+	// Refs may contain slashes (e.g. `feature/x`), so encode each segment but
+	// keep the separators intact.
+	const refPath = ref ? `/${encodeRef(ref)}` : "";
+	const url = `https://api.github.com/repos/${owner}/${repo}/${endpoint}${refPath}`;
+
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			// Capture the redirect ourselves so we can hand back the signed
+			// codeload URL instead of streaming the (potentially huge) archive
+			// body through the Worker.
+			redirect: "manual",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "github-mcp-proxy",
+			},
+		});
+	} catch (e) {
+		return errorResult(
+			`download_repository_archive: request to GitHub failed: ${String(e)}`,
+		);
+	}
+
+	if (res.status >= 300 && res.status < 400) {
+		const location = res.headers.get("Location");
+		if (!location) {
+			return errorResult(
+				`download_repository_archive: GitHub returned a ${res.status} redirect without a Location header.`,
+			);
+		}
+		const refLabel = ref || "(default branch)";
+		return {
+			content: [
+				{
+					type: "text",
+					text:
+						`Archive download URL for ${owner}/${repo} @ ${refLabel} (${format}):\n` +
+						`${location}\n\n` +
+						"This URL is temporary (valid for roughly a few minutes) and requires no further " +
+						"authentication. Fetch it to download the archive.",
+				},
+			],
+		};
+	}
+
+	if (res.status === 404) {
+		return errorResult(
+			`download_repository_archive: repository '${owner}/${repo}'` +
+				(ref ? ` or ref '${ref}'` : "") +
+				" not found, or the token lacks access.",
+		);
+	}
+
+	return errorResult(
+		`download_repository_archive: unexpected response from GitHub: ${res.status} ${await safeText(res)}`,
+	);
+}
+
+function encodeRef(ref: string): string {
+	return ref.split("/").map(encodeURIComponent).join("/");
+}
+
+async function safeText(res: Response): Promise<string> {
+	try {
+		return await res.text();
+	} catch {
+		return "";
+	}
+}
+
+function errorResult(text: string): ToolResult {
+	return { content: [{ type: "text", text }], isError: true };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import { GitHubHandler } from "./github-handler";
 import { handlePatchFiles, PATCH_FILES_TOOL } from "./patch-files";
+import { DOWNLOAD_ARCHIVE_TOOL, handleDownloadArchive } from "./download-archive";
+
+// Custom tools this proxy advertises and services itself, on top of the
+// upstream GitHub MCP toolset.
+const CUSTOM_TOOLS = [PATCH_FILES_TOOL, DOWNLOAD_ARCHIVE_TOOL];
 
 const UPSTREAM_MCP_URL = "https://api.githubcopilot.com/mcp/x/all/";
 
@@ -33,7 +38,7 @@ const proxyHandler: ExportedHandler<Env> & Pick<Required<ExportedHandler<Env>>, 
 		const upstreamUrl = new URL(subPath, UPSTREAM_MCP_URL);
 
 		// Intercept JSON-RPC on POSTs to the MCP root so we can advertise and
-		// service our own `patch_files` tool. Everything else streams through.
+		// service our own custom tools. Everything else streams through.
 		if (
 			request.method === "POST" &&
 			subPath === "" &&
@@ -43,12 +48,17 @@ const proxyHandler: ExportedHandler<Env> & Pick<Required<ExportedHandler<Env>>, 
 			const parsed = tryParseJson(bodyText);
 			const single = !Array.isArray(parsed) && isJsonRpcRequest(parsed) ? parsed : null;
 
-			if (single?.method === "tools/call" && single.params?.name === "patch_files") {
-				const result = await handlePatchFiles(
-					single.params?.arguments ?? {},
-					props.accessToken,
-				);
-				return jsonRpcResponse(single.id ?? null, result);
+			if (single?.method === "tools/call") {
+				const toolName = single.params?.name;
+				const toolArgs = single.params?.arguments ?? {};
+				if (toolName === "patch_files") {
+					const result = await handlePatchFiles(toolArgs, props.accessToken);
+					return jsonRpcResponse(single.id ?? null, result);
+				}
+				if (toolName === "download_repository_archive") {
+					const result = await handleDownloadArchive(toolArgs, props.accessToken);
+					return jsonRpcResponse(single.id ?? null, result);
+				}
 			}
 
 			const upstreamResponse = await forwardRequest(
@@ -59,7 +69,7 @@ const proxyHandler: ExportedHandler<Env> & Pick<Required<ExportedHandler<Env>>, 
 			);
 
 			if (single?.method === "tools/list") {
-				return injectPatchFilesTool(upstreamResponse);
+				return injectCustomTools(upstreamResponse);
 			}
 			return upstreamResponse;
 		}
@@ -125,14 +135,14 @@ function jsonRpcResponse(id: string | number | null, result: unknown): Response 
 	);
 }
 
-async function injectPatchFilesTool(upstreamResponse: Response): Promise<Response> {
+async function injectCustomTools(upstreamResponse: Response): Promise<Response> {
 	const ct = upstreamResponse.headers.get("content-type") ?? "";
 
 	if (ct.includes("application/json")) {
 		const text = await upstreamResponse.text();
 		const obj = tryParseJson(text) as any;
 		if (obj?.result?.tools && Array.isArray(obj.result.tools)) {
-			obj.result.tools.push(PATCH_FILES_TOOL);
+			obj.result.tools.push(...CUSTOM_TOOLS);
 			return rewriteBody(upstreamResponse, JSON.stringify(obj));
 		}
 		return rewriteBody(upstreamResponse, text);
@@ -143,7 +153,7 @@ async function injectPatchFilesTool(upstreamResponse: Response): Promise<Respons
 		const rewritten = text.replace(/^data:[ \t]?(.+)$/gm, (line, payload) => {
 			const obj = tryParseJson(payload) as any;
 			if (obj?.result?.tools && Array.isArray(obj.result.tools)) {
-				obj.result.tools.push(PATCH_FILES_TOOL);
+				obj.result.tools.push(...CUSTOM_TOOLS);
 				return `data: ${JSON.stringify(obj)}`;
 			}
 			return line;


### PR DESCRIPTION
## What

Adds a new custom MCP tool, **`download_repository_archive`**, on top of the upstream GitHub MCP toolset. It returns a temporary, signed download URL for a repository archive (zip or tar.gz) via GitHub's archive API.

This is the "clone/fetch a repository" capability discussed for this branch. Rather than streaming a (potentially huge) archive body through the Worker or aggregating files into the LLM context, the tool hands back a download URL — the chosen design after weighing the trade-offs.

## How it works

- Calls GitHub's archive endpoint: `GET /repos/{owner}/{repo}/{zipball|tarball}/{ref}` with the user's OAuth token.
- Because the request is authenticated, it works for **private** repositories.
- The request uses `redirect: "manual"` so the proxy captures the `302` and returns the resulting `codeload.github.com` URL.
- That signed URL is short-lived (~a few minutes) and downloadable with **no further authentication** — the GitHub token is never embedded in the returned URL.

## Tool arguments

| Argument | Required | Description |
|---|---|---|
| `owner` | ✅ | Repository owner (user/org) |
| `repo` | ✅ | Repository name |
| `ref` | — | Branch, tag, or commit SHA. Defaults to the repository's default branch |
| `format` | — | `zip` (default) or `tar.gz` |

## Wiring

- `src/download-archive.ts` — new tool definition + handler.
- `src/index.ts` — registers the tool in a `CUSTOM_TOOLS` list, dispatches `tools/call`, and advertises it in `tools/list` (generalized the former `injectPatchFilesTool` to `injectCustomTools`).
- `src/download-archive.test.ts` — schema, argument validation, and API-flow tests (signed-URL return, tarball/ref path building, ref encoding, missing Location, 404, 5xx, fetch rejection).
- `README.md` — documents both custom tools (`patch_files`, `download_repository_archive`).

## Testing

- `npm test` — 32 passing (3 files).
- `npm run type-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011qujoGbUFi3hJWAeYiJiyF)_